### PR TITLE
[PAN-2219] fix IAM schemas rejecting email-style user identifiers

### DIFF
--- a/iam/group.schema.json
+++ b/iam/group.schema.json
@@ -8,6 +8,7 @@
     "name": {
       "type": "string",
       "pattern": "^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$",
+      "minLength": 1,
       "maxLength": 63,
       "description": "The unique name of the group. Lowercase alphanumeric or hyphens, not starting/ending with hyphen, max 63 chars."
     },
@@ -16,6 +17,12 @@
       "minLength": 1,
       "maxLength": 150,
       "description": "Display name for the group. If not provided, the value of 'name' will be used."
+    },
+    "sso_name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 150,
+      "description": "SSO name used to map SSO-provided groups onto HQ groups. Useful when SAML assertions carry group UUIDs (e.g. from Active Directory). If not provided, the value of 'name' will be used."
     },
     "description": {
       "type": "string",

--- a/iam/policy.schema.json
+++ b/iam/policy.schema.json
@@ -650,15 +650,15 @@
             "oneOf": [
               {
                 "type": "string",
-                "pattern": "^(\\*|(administration:(connection|license|lenses-logs|lenses-configuration|setting)|applications:(external-application)|alerts:(rule|event|channel)|audit:(log|channel)|data-policies:(policy)|environments:(environment|kafka-connection)|governance:(request|rule)|iam:(user|group|role|service-account)|k2k:(app)|kafka-connect:(connector|cluster)|kafka:(topic|acl|quota|consumer-group|cluster)|kubernetes:(cluster|namespace)|schemas:(registry|schema)|sql-streaming:(sql-processor)):(\\*|[a-zA-Z0-9-/*]+))$",
-                "description": "Lenses Resource Name (LRN) in the format service:resource-type:resource-id. Wildcards (*) are allowed, or '*' for all."
+                "pattern": "^(\\*|(administration:(connection|license|lenses-logs|lenses-configuration|setting)|applications:(external-application)|alerts:(rule|event|channel)|audit:(log|channel)|data-policies:(policy)|environments:(environment|kafka-connection)|governance:(request|rule)|iam:(user|group|role|service-account)|k2k:(app)|kafka-connect:(connector|cluster)|kafka:(topic|acl|quota|consumer-group|cluster)|kubernetes:(cluster|namespace)|schemas:(registry|schema)|sql-streaming:(sql-processor)):(\\*|[a-zA-Z0-9-/*.@_+]+))$",
+                "description": "Lenses Resource Name (LRN) in the format service:resource-type:resource-id. Wildcards (*) are allowed, or '*' for all. Email-style IDs are supported for iam:user (e.g. iam:user:john.doe@example.com)."
               },
               {
                 "type": "array",
                 "items": {
                   "type": "string",
-                  "pattern": "^(\\*|(administration:(connection|license|lenses-logs|lenses-configuration|setting)|applications:(external-application)|alerts:(rule|event|channel)|audit:(log|channel)|data-policies:(policy)|environments:(environment|kafka-connection)|governance:(request|rule)|iam:(user|group|role|service-account)|k2k:(app)|kafka-connect:(connector|cluster)|kafka:(topic|acl|quota|consumer-group|cluster)|kubernetes:(cluster|namespace)|schemas:(registry|schema)|sql-streaming:(sql-processor)):(\\*|[a-zA-Z0-9-/*]+))$",
-                  "description": "Lenses Resource Name (LRN) in the format service:resource-type:resource-id. Wildcards (*) are allowed, or '*' for all."
+                  "pattern": "^(\\*|(administration:(connection|license|lenses-logs|lenses-configuration|setting)|applications:(external-application)|alerts:(rule|event|channel)|audit:(log|channel)|data-policies:(policy)|environments:(environment|kafka-connection)|governance:(request|rule)|iam:(user|group|role|service-account)|k2k:(app)|kafka-connect:(connector|cluster)|kafka:(topic|acl|quota|consumer-group|cluster)|kubernetes:(cluster|namespace)|schemas:(registry|schema)|sql-streaming:(sql-processor)):(\\*|[a-zA-Z0-9-/*.@_+]+))$",
+                  "description": "Lenses Resource Name (LRN) in the format service:resource-type:resource-id. Wildcards (*) are allowed, or '*' for all. Email-style IDs are supported for iam:user (e.g. iam:user:john.doe@example.com)."
                 }
               }
             ]

--- a/iam/role.schema.json
+++ b/iam/role.schema.json
@@ -8,6 +8,7 @@
     "name": {
       "type": "string",
       "pattern": "^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$",
+      "minLength": 1,
       "maxLength": 63,
       "description": "The unique name of the IAM role. Lowercase alphanumeric or hyphens, not starting/ending with hyphen, max 63 chars."
     },
@@ -15,7 +16,12 @@
       "type": "string",
       "minLength": 1,
       "maxLength": 150,
-      "description": "Display name for the IAM role."
+      "description": "Display name for the IAM role. If not provided, the value of 'name' will be used."
+    },
+    "description": {
+      "type": "string",
+      "maxLength": 280,
+      "description": "Description of the IAM role."
     },
     "policy": {
       "type": "array",

--- a/iam/service-account.schema.json
+++ b/iam/service-account.schema.json
@@ -8,6 +8,7 @@
     "name": {
       "type": "string",
       "pattern": "^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$",
+      "minLength": 1,
       "maxLength": 63,
       "description": "The unique name of the service account. Lowercase alphanumeric or hyphens, not starting/ending with hyphen, max 63 chars."
     },

--- a/iam/user.schema.json
+++ b/iam/user.schema.json
@@ -7,9 +7,9 @@
   "properties": {
     "name": {
       "type": "string",
-      "pattern": "^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$",
-      "maxLength": 63,
-      "description": "The unique name of the user. Lowercase alphanumeric or hyphens, not starting/ending with hyphen, max 63 chars."
+      "minLength": 1,
+      "maxLength": 100,
+      "description": "The unique name of the user. Free-form string (commonly an email address for SSO-provisioned users), 1-100 chars."
     },
     "display_name": {
       "type": "string",


### PR DESCRIPTION
## Summary

- Widen the `resource` regex in `iam/policy.schema.json` to allow `@`, `.`, `_`, `+` in the resource-id portion of an LRN — fixes `iam:user:john.doe@example.com` being wrongly rejected by HQ UI autocomplete (`monaco-yaml`) even though the backend accepts it.
- Audit `user`/`role`/`group`/`service-account` schemas against `panoptes-backend/cmd/hq/apidefs.gen.go` and align the client with backend truth: `user.name` is **intentionally free-form** on the backend (no `hq-resource-name` format, `maxLength: 100`), while the other three use the stricter `hq-resource-name` layout.
- Fill in missing fields the client schema was silently dropping: `role.description`, `group.sso_name`, and `minLength: 1` on every `name` field.

Jira: [PAN-2219](https://landoop.atlassian.net/browse/PAN-2219)

## Root cause

`iam/policy.schema.json` used `[a-zA-Z0-9-/*]+` for the LRN resource-id class — no `@`, no `.`, so any email-shaped identifier failed validation in the browser. The backend's `IAMUserResource.Username` is documented as "Free-form" (`panoptes-backend/internal/iam/perms/policy.gen.go:3921`) and `model_test.go:318-325` explicitly tests `iam:user:spiros@lenses.io` and `iam:user:*@lenses.io` as valid. The client schema was stricter than the backend — the worst of both worlds.

While fixing that, checked every `name` field in the IAM schemas against its backend OpenAPI counterpart and found `user.schema.json` applying a DNS-style regex with `maxLength: 63` — but `apiObjCreateUserRequest` (`cmd/hq/apidefs.gen.go:884`) has no `format` key and `maxLength: 100`. The other three (`group`, `role`, `service-account`) all carry `format: "hq-resource-name"` in the backend, and the existing client regex matches that format — so those only needed the missing `minLength: 1`.

## Changes

| File | Change |
|---|---|
| `iam/policy.schema.json` | Resource-id char class `[a-zA-Z0-9-/*]` → `[a-zA-Z0-9-/*.@_+]` (both the single-string and array items forms). LRN descriptions updated to document email-style IDs for `iam:user`. |
| `iam/user.schema.json` | Drop DNS-style `pattern`, `maxLength` 63 → 100, add `minLength: 1`, rewrite description to "free-form, commonly an email address for SSO-provisioned users". |
| `iam/role.schema.json` | Add `minLength: 1` to `name`; add missing `description` field (maxLength 280); clarify `display_name` description. |
| `iam/group.schema.json` | Add `minLength: 1` to `name`; add missing `sso_name` field (maxLength 150) — important for SAML group mapping. |
| `iam/service-account.schema.json` | Add `minLength: 1` to `name`. |

## Test plan

- [x] `ajv compile --spec=draft7 --strict=false` passes for all five schemas
- [x] `iam:user:john.doe+test@example.com` now validates
- [x] `iam:user:spiros@lenses.io` validates
- [x] `iam:user:*@lenses.io` (wildcard prefix email) validates
- [x] 99-char user name validates (within new `maxLength: 100`)
- [x] Group with `sso_name` field validates
- [x] Role with `description` field validates
- [x] `iam:user:john doe@example.com` (space) is still rejected
- [x] 150-char user name is rejected (over new maxLength)
- [x] Empty `name` is rejected (new `minLength: 1`)
- [ ] Smoke-test HQ UI role editor after merge by authoring an email-based policy, once the `raw.githubusercontent.com` cache expires

## Consumer

`panoptes-ui/apps/hq-ui/src/app/common/config.ts:27` pulls these schemas straight from `raw.githubusercontent.com/lensesio/json-schemas/refs/heads/main/...` into `monaco-yaml`. Once merged and the CDN cache turns over, the fix takes effect in the browser without a UI release.

## Out of scope — follow-up

`role.schema.json` has a pre-existing structural bug: `policy.items.$ref` points at the whole `policy.schema.json` wrapper document, but per `apiObjCreateRoleRequest` (`cmd/hq/apidefs.gen.go:812`) a role's `policy` should be a flat array of `PermissionStatement` objects. This PR leaves that alone and will be tackled in a separate follow-up since it's independent of the email bug and changes the schema shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PAN-2219]: https://landoop.atlassian.net/browse/PAN-2219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ