### PR TITLE
[PAN-2220] fix role.schema.json policy items + relax additionalProperties

### DIFF
--- a/iam/policy.schema.json
+++ b/iam/policy.schema.json
@@ -10,7 +10,11 @@
       "type": "array",
       "description": "List of policy statements",
       "markdownDescription": "List of policy statements. [View policy documentation](https://docs.lenses.io/latest/user-guide/iam)",
-      "items": {
+      "items": { "$ref": "#/definitions/PermissionStatement" }
+    }
+  },
+  "definitions": {
+    "PermissionStatement": {
         "type": "object",
         "required": ["effect", "action", "resource"],
         "properties": {
@@ -665,7 +669,6 @@
           }
         }        
       }
-    }
   },
   "defaultSnippets": [
     {

--- a/iam/role.schema.json
+++ b/iam/role.schema.json
@@ -27,7 +27,7 @@
       "type": "array",
       "minItems": 1,
       "items": {
-        "$ref": "policy.schema.json"
+        "$ref": "policy.schema.json#/definitions/PermissionStatement"
       },
       "description": "List of permission statements for this role."
     },

--- a/iam/role.schema.json
+++ b/iam/role.schema.json
@@ -43,6 +43,5 @@
       },
       "description": "Custom string key/values for the role."
     }
-  },
-  "additionalProperties": false
-} 
+  }
+}


### PR DESCRIPTION
## Summary

Two small, focused changes to `iam/role.schema.json` and `iam/policy.schema.json` that clean up issues discovered while fixing [PAN-2219](https://landoop.atlassian.net/browse/PAN-2219) / #81 (merged).

1. **Fix structural mismatch between `role.schema.json` and the backend.** Extract the permission-statement sub-schema in `iam/policy.schema.json` into a reusable `definitions/PermissionStatement` block, and point `role.schema.json`'s `policy.items` at that named definition instead of the whole `policy.schema.json` wrapper document. A role YAML now matches the backend's flat `[{effect, action, resource}, ...]` shape.
2. **Remove the lone `additionalProperties: false`** from `role.schema.json`. It was the only IAM schema enforcing this; dropping it aligns with `policy`, `user`, `group`, and `service-account`.

Jira: [PAN-2220](https://landoop.atlassian.net/browse/PAN-2220)

## Context

### Why change 1 — `role.schema.json` was wrong shape

Before this PR, `role.schema.json` declared:

```json
"policy": {
  "type": "array",
  "items": { "$ref": "policy.schema.json" }
}
```

But `policy.schema.json` is the **wrapper document** schema — it describes `{"policy": [{effect, action, resource}, ...]}`. So each item in a role's `policy` array was being validated against the wrapper document, which forced this absurd double-nesting:

```yaml
name: my-role
policy:
  - policy:                    # never actually worked against the backend
      - effect: allow
        action: iam:ListUsers
        resource: iam:user:*
```

Per `panoptes-backend/cmd/hq/apidefs.gen.go:812-848` (`apiObjCreateRoleRequest`), a role's `policy` is a flat array of `PermissionStatement`:

```json
"policy": {
  "description": "Contains a list of permission statements.",
  "items": { "$ref": "#/components/schemas/PermissionStatement" },
  "type": "array"
}
```

— which is exactly the inner shape that `policy.schema.json` already described. This PR extracts it into a named `definitions/PermissionStatement` and references it from both files.

### Why change 2 — consistency + avoiding drift-induced false positives

`role.schema.json` was the **only** IAM schema with `additionalProperties: false` at the top level. The other four (policy, user, group, service-account) silently accept unknown fields. That inconsistency is confusing (authors get typo protection in role YAML but not user YAML), and the strict stance in this repo actively causes problems when the backend outpaces the schemas.

PAN-2219 was exactly that class of drift — a closed set (the resource-id regex) in the client schema got out of sync with what the backend accepts, producing false-positive errors in HQ UI autocomplete. Keeping `additionalProperties: false` in `role.schema.json` would have set us up for the same story: next time the backend adds a field to `Role`, customer editors would start showing red squigglies until this repo catches up. Since the backend is the authoritative validator (the json-schemas repo's purpose is editor autocomplete and snippet hints, not strict validation), the safer default is lax.

The inner `additionalProperties` under `metadata` (which constrains individual metadata entry values) is unchanged — only the top-level strict check is removed.

## Changes

### `iam/policy.schema.json`

- Move the permission-statement object from `properties.policy.items` to `definitions.PermissionStatement`.
- `properties.policy.items` becomes `{ "$ref": "#/definitions/PermissionStatement" }`.
- The extracted block keeps its original 2-space-deeper indentation so git's move detection recognises it as unmoved — the diff is 7 lines of structural change instead of ~700 lines of whitespace churn. JSON parsers don't care about the extra indentation; reviewers do.

### `iam/role.schema.json`

- `policy.items.$ref` changes from `policy.schema.json` to `policy.schema.json#/definitions/PermissionStatement`.
- Top-level `additionalProperties: false` removed (second commit on this branch).

## Test plan

Validated with `ajv compile --spec=draft7 --strict=false` and a fixture suite via programmatic `ajv` with both schemas loaded:

- [x] Flat-statement role (backend shape) validates — `{name, policy: [{effect, action, resource}]}`
- [x] Old double-nested role shape correctly rejected
- [x] Wrapper policy document `{policy: [{...}]}` still validates against `policy.schema.json`
- [x] Role with unknown top-level field (`future_field: "..."`) now accepted (was previously rejected)
- [x] Role with PR #81's new `description` field validates
- [x] Role with email-based resource (`iam:user:john.doe@example.com`, from PR #81's LRN regex fix) validates end-to-end through both fixes
- [ ] Smoke-test HQ UI role editor after merge to confirm no regression in the monaco-yaml validation path (only the `$ref` indirection changes for that consumer — content and structure are identical)

## Consumers

- **HQ UI monaco-yaml editor** (`panoptes-ui/apps/hq-ui/src/app/common/config.ts:27`) loads `policy.schema.json` directly for IAM role editing. Unchanged — it still validates the same wrapper-document form, now routed through the named definition.
- **VS Code YAML authoring** (README's `yaml.schemas` glob `**/role.{yaml,yml}`) loads `role.schema.json`. After this PR, authors will be prompted to write the **flat statement** form, which matches what the backend accepts. Any role YAML authored before this PR that used the old double-nested form will now fail validation — but those YAMLs were never backend-valid in the first place, so anyone relying on them was silently broken.

## Commits

- `[PAN-2220] fix role.schema.json policy items to reference PermissionStatement` — the structural fix
- `[PAN-2220] drop additionalProperties: false from role.schema.json` — the consistency fix

Two commits kept separate because they address different concerns; squash or keep at your preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PAN-2219]: https://landoop.atlassian.net/browse/PAN-2219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PAN-2220]: https://landoop.atlassian.net/browse/PAN-2220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PAN-2220]: https://landoop.atlassian.net/browse/PAN-2220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ