### PR TITLE
[PAN-2488] Add new topic actions to Data Engineer policy snippet

### DIFF
--- a/iam/policy.schema.json
+++ b/iam/policy.schema.json
@@ -780,7 +780,9 @@
               "kafka:GetTopicDetails",
               "kafka:ReadTopicData",
               "kafka:CreateTopic",
-              "kafka:UpdateTopicDetails"
+              "kafka:UpdateTopicDetails",
+              "kafka:UpdateTopicFormat",
+              "kafka:UpdateTopicMetadata"
             ],
             "resource": ["kafka:topic:*/kafka/*"]
           },


### PR DESCRIPTION
## What

Follow-up to #89 (which added `kafka:UpdateTopicFormat`/`kafka:UpdateTopicMetadata` to the action **enum**). The `defaultSnippets` example policies weren't touched there — and the **Data Engineer Policy** snippet manages topics but only listed `kafka:UpdateTopicDetails`.

Adds the two sibling actions to that snippet's topic-management statement so the ready-to-use template stays consistent with the split (a data engineer who "can manage topics" should be able to set topic format and metadata).

## Scope
- Only the **Data Engineer** snippet changes. **Read-Only** (reads only) and **Administrator** (`*`) need nothing.

## Verification
- Valid JSON; every snippet action is present in the schema's action enum.
- `npm run validate-iam` passes (ajv).

Companion update to the hq-ui bundled fallback copy follows. Tracked in PAN-2488.

🤖 Generated with [Claude Code](https://claude.com/claude-code)