### PR TITLE
Add GSSAPI SASL mechanism and keytab to Kafka connection schema

### DIFF
--- a/agent/provisioning.schema-6.1.json
+++ b/agent/provisioning.schema-6.1.json
@@ -156,9 +156,10 @@
       "properties": {
         "value": {
           "type": "string",
-          "description": "Enter the SASL mechanism (PLAIN, SCRAM-SHA-256, SCRAM-SHA-512).",
+          "description": "Enter the SASL mechanism (PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, GSSAPI, AWS_MSK_IAM).",
           "enum": [
             "AWS_MSK_IAM",
+            "GSSAPI",
             "PLAIN",
             "SCRAM-SHA-256",
             "SCRAM-SHA-512"
@@ -175,7 +176,7 @@
       "properties": {
         "value": {
           "type": "string",
-          "description": "Enter the JAAS config string. For SCRAM-SHA-256 or SCRAM-SHA-512: org.apache.kafka.common.security.scram.ScramLoginModule required username=\"<user>\" password=\"<pass>\"; \n\nFor AWS_MSK_IAM: software.amazon.msk.auth.iam.IAMLoginModule required; and additionalProperties sasl.client.callback.handler.class: software.amazon.msk.auth.iam.IAMClientCallbackHandler",
+          "description": "Enter the JAAS config string. For SCRAM-SHA-256 or SCRAM-SHA-512: org.apache.kafka.common.security.scram.ScramLoginModule required username=\"<user>\" password=\"<pass>\"; \n\nFor GSSAPI (Kerberos): com.sun.security.auth.module.Krb5LoginModule required useKeyTab=true storeKey=true useTicketCache=false serviceName=\"kafka\" principal=\"<user>@<REALM>\"; and provide the keytab via the keytab field.\n\nFor AWS_MSK_IAM: software.amazon.msk.auth.iam.IAMLoginModule required; and additionalProperties sasl.client.callback.handler.class: software.amazon.msk.auth.iam.IAMClientCallbackHandler",
           "x-secret": true,
           "anyOf": [
             {
@@ -191,6 +192,19 @@
         "value"
       ],
       "multiline": true
+    },
+    "keytab": {
+      "type": "object",
+      "description": "Kerberos keytab file for GSSAPI authentication.",
+      "properties": {
+        "file": {
+          "type": "string",
+          "description": "Enter a unique keytab file name for Kerberos (GSSAPI) authentication."
+        }
+      },
+      "required": [
+        "file"
+      ]
     },
     "sslKeystore": {
       "type": "object",
@@ -1486,6 +1500,9 @@
               },
               "saslJaasConfig": {
                 "$ref": "#/definitions/saslJaasConfig"
+              },
+              "keytab": {
+                "$ref": "#/definitions/keytab"
               },
               "additionalProperties": {
                 "$ref": "#/definitions/additionalProperties"
@@ -3983,6 +4000,83 @@
               },
               "saslJaasConfig": {
                 "value": "org.apache.kafka.common.security.scram.ScramLoginModule required username=\"\" password=\"\";"
+              },
+              "additionalProperties": {
+                "value": {}
+              },
+              "## Optional JMX metrics": "Uncomment below to enable JMX metrics",
+              "# metricsType": {
+                "# value": ""
+              },
+              "# metricsPort": {
+                "# value": 9581
+              },
+              "# metricsSsl": {
+                "# value": true
+              },
+              "# metricsUsername": {
+                "# value": ""
+              },
+              "# metricsPassword": {
+                "# value": ""
+              },
+              "# metricsHttpSuffix": {
+                "# value": 30000
+              },
+              "# metricsHttpTimeout": {
+                "# value": 30000
+              },
+              "# metricsCustomUrlMappings": {
+                "# value": {
+                  "# kafka1:9092": "kafka1_jmx_metrics:9581",
+                  "# kafka2:9092": "kafka2_jmx_metrics:9581"
+                }
+              },
+              "# metricsRateLimitingMaxRetries": {
+                "# value": 5
+              },
+              "# metricsRateLimitingBackoff": {
+                "# value": 30000
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "label": "Kafka, SASL_SSL, GSSAPI",
+      "body": {
+        "## Template": "Kafka, SASL_SSL, GSSAPI",
+        "kafka": [
+          {
+            "name": "kafka",
+            "editorTag": "SASL_SSL, GSSAPI",
+            "version": 1,
+            "tags": "[]",
+            "configuration": {
+              "kafkaBootstrapServers": {
+                "value": [
+                  "<broker1>:9092",
+                  "<broker2>:9092"
+                ]
+              },
+              "protocol": {
+                "value": "SASL_SSL"
+              },
+              "sslTruststore": {
+                "file": "kafka-truststore.jks"
+              },
+              "sslTruststorePassword": {
+                "value": ""
+              },
+              "saslMechanism": {
+                "value": "GSSAPI"
+              },
+              "saslJaasConfig": {
+                "value": "com.sun.security.auth.module.Krb5LoginModule required useKeyTab=true storeKey=true useTicketCache=false serviceName=\"kafka\" principal=\"<user>@<REALM>\";"
+              },
+              "keytab": {
+                "file": "kafka.keytab"
               },
               "additionalProperties": {
                 "value": {}

--- a/agent/provisioning.schema.json
+++ b/agent/provisioning.schema.json
@@ -239,9 +239,10 @@
                 "properties": {
                   "value": {
                     "type": "string",
-                    "description": "Enter the SASL mechanism (PLAIN, SCRAM-SHA-256, SCRAM-SHA-512).",
+                    "description": "Enter the SASL mechanism (PLAIN, SCRAM-SHA-256, SCRAM-SHA-512, GSSAPI, AWS_MSK_IAM).",
                     "enum": [
                       "AWS_MSK_IAM",
+                      "GSSAPI",
                       "PLAIN",
                       "SCRAM-SHA-256",
                       "SCRAM-SHA-512"
@@ -256,12 +257,23 @@
                 "properties": {
                   "value": {
                     "type": "string",
-                    "description": "Enter the JAAS config string. For SCRAM-SHA-256 or SCRAM-SHA-512: org.apache.kafka.common.security.scram.ScramLoginModule required username=\"<user>\" password=\"<pass>\"; \n\nFor AWS_MSK_IAM: software.amazon.msk.auth.iam.IAMLoginModule required; and additionalProperties sasl.client.callback.handler.class: software.amazon.msk.auth.iam.IAMClientCallbackHandler",
+                    "description": "Enter the JAAS config string. For SCRAM-SHA-256 or SCRAM-SHA-512: org.apache.kafka.common.security.scram.ScramLoginModule required username=\"<user>\" password=\"<pass>\"; \n\nFor GSSAPI (Kerberos): com.sun.security.auth.module.Krb5LoginModule required useKeyTab=true storeKey=true useTicketCache=false serviceName=\"kafka\" principal=\"<user>@<REALM>\"; and provide the keytab via the keytab field.\n\nFor AWS_MSK_IAM: software.amazon.msk.auth.iam.IAMLoginModule required; and additionalProperties sasl.client.callback.handler.class: software.amazon.msk.auth.iam.IAMClientCallbackHandler",
                     "minLength": 1
                   }
                 },
                 "required": ["value"],
                 "multiline": true
+              },
+              "keytab": {
+                "type": "object",
+                "description": "Kerberos keytab file for GSSAPI authentication.",
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "description": "Enter a unique keytab file name for Kerberos (GSSAPI) authentication."
+                  }
+                },
+                "required": ["file"]
               },
               "additionalProperties": {
                 "type": "object",
@@ -2862,6 +2874,75 @@
               },
               "# metricsPassword": {
                 "# value": ""
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "label": "Kafka, SASL_SSL, GSSAPI",
+      "body": {
+        "## Template": "Kafka, SASL_SSL, GSSAPI",
+        "kafka": [
+          {
+            "name": "kafka",
+            "editorTag": "SASL_SSL, GSSAPI",
+            "version": 1,
+            "tags": "[]",
+            "configuration": {
+              "kafkaBootstrapServers": {
+                "value": [
+                  "SASL_SSL://<broker1>:9092",
+                  "SASL_SSL://<broker2>:9092"
+                ]
+              },
+              "protocol": {
+                "value": "SASL_SSL"
+              },
+              "saslMechanism": {
+                "value": "GSSAPI"
+              },
+              "saslJaasConfig": {
+                "value": "com.sun.security.auth.module.Krb5LoginModule required useKeyTab=true storeKey=true useTicketCache=false serviceName=\"kafka\" principal=\"<user>@<REALM>\";"
+              },
+              "keytab": {
+                "file": "kafka.keytab"
+              },
+              "sslTruststore": {
+                "file": "kafka-truststore.jks"
+              },
+              "sslTruststorePassword": {
+                "value": ""
+              },
+              "## Optional mutual SSL/TLS": "Uncomment the properties below to enable mutual SSL/TLS",
+              "# sslKeystore": {
+                "# file": "kafka-keystore.jks"
+              },
+              "# sslKeystorePassword": {
+                "# value": ""
+              },
+              "# sslKeyPassword": {
+                "# value": ""
+              },
+              "## Optional JMX metrics": "Uncomment the properties below to enable JMX metrics",
+              "# metricsPort": {
+                "# value": 9581
+              },
+              "# metricsType": {
+                "# value": ""
+              },
+              "# metricsSsl": {
+                "# value": true
+              },
+              "# metricsUsername": {
+                "# value": ""
+              },
+              "# metricsPassword": {
+                "# value": ""
+              },
+              "# metricsHttpTimeout": {
+                "# value": 30000
               }
             }
           }


### PR DESCRIPTION
## Problem

The provisioning config editor (Lenses Studio) rejects Kafka Cluster connections that use `SASL_SSL` + `GSSAPI` (Kerberos), so they can't be tested or applied — even though Kerberos is documented as supported.

Root cause: the provisioning schemas restrict `saslMechanism.value` to a closed enum (`AWS_MSK_IAM`, `PLAIN`, `SCRAM-SHA-256`, `SCRAM-SHA-512`) that omits `GSSAPI`, and they define no `keytab` field. The Agent's own `agent_KafkaProvisioningConfiguration` (OpenAPI 6.2) does **not** enum-restrict `saslMechanism` and **does** define a `keytab` field — so the editor schema was stricter than the backend and was the sole blocker.

## Changes

Applied to both `agent/provisioning.schema.json` and `agent/provisioning.schema-6.1.json`:

1. Add `GSSAPI` to the `saslMechanism` enum
2. Add a `keytab` file field (mirroring `sslTruststore`)
3. Document the `Krb5LoginModule` JAAS config in the descriptions — left **unconstrained** (no validating pattern), to avoid restricting users
4. Add a "Kafka, SASL_SSL, GSSAPI" connection template

## Verification

- Both schemas compile (ajv); `GSSAPI` validates with and without a keytab; an unknown mechanism is still rejected; existing PLAIN/SCRAM conditionals still fire.
- `jq` lint (CI-equivalent) and `format-check` pass.

## Notes

Separate pre-existing issue (out of scope): `npm run validate-agent` (`ajv compile`) already fails on `main` because the PLAIN/SCRAM patterns use `\"`, an invalid escape under ajv's ECMAScript unicode-mode regex. CI only runs `jq` linting so it's never caught — worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)