### PR TITLE
Add GSSAPI editor tags and SASL_PLAINTEXT template to Kafka schema

### DIFF
--- a/agent/provisioning.schema-6.1.json
+++ b/agent/provisioning.schema-6.1.json
@@ -22,9 +22,11 @@
         "SASL_PLAINTEXT, PLAIN",
         "SASL_PLAINTEXT, SCRAM-SHA-256",
         "SASL_PLAINTEXT, SCRAM-SHA-512",
+        "SASL_PLAINTEXT, GSSAPI",
         "SASL_SSL, PLAIN",
         "SASL_SSL, SCRAM-SHA-256",
         "SASL_SSL, SCRAM-SHA-512",
+        "SASL_SSL, GSSAPI",
         "SSL/TLS",
         "Mutual SSL/TLS",
         "Zookeeper",
@@ -1262,9 +1264,11 @@
         "SASL_PLAINTEXT, PLAIN",
         "SASL_PLAINTEXT, SCRAM-SHA-256",
         "SASL_PLAINTEXT, SCRAM-SHA-512",
+        "SASL_PLAINTEXT, GSSAPI",
         "SASL_SSL, PLAIN",
         "SASL_SSL, SCRAM-SHA-256",
         "SASL_SSL, SCRAM-SHA-512",
+        "SASL_SSL, GSSAPI",
         "SSL/TLS",
         "Mutual SSL/TLS"
       ]
@@ -3751,6 +3755,77 @@
               },
               "saslJaasConfig": {
                 "value": "org.apache.kafka.common.security.scram.ScramLoginModule required username=\"\" password=\"\";"
+              },
+              "additionalProperties": {
+                "value": {}
+              },
+              "## Optional JMX metrics": "Uncomment below to enable JMX metrics",
+              "# metricsType": {
+                "# value": ""
+              },
+              "# metricsPort": {
+                "# value": 9581
+              },
+              "# metricsSsl": {
+                "# value": true
+              },
+              "# metricsUsername": {
+                "# value": ""
+              },
+              "# metricsPassword": {
+                "# value": ""
+              },
+              "# metricsHttpSuffix": {
+                "# value": 30000
+              },
+              "# metricsHttpTimeout": {
+                "# value": 30000
+              },
+              "# metricsCustomUrlMappings": {
+                "# value": {
+                  "# kafka1:9092": "kafka1_jmx_metrics:9581",
+                  "# kafka2:9092": "kafka2_jmx_metrics:9581"
+                }
+              },
+              "# metricsRateLimitingMaxRetries": {
+                "# value": 5
+              },
+              "# metricsRateLimitingBackoff": {
+                "# value": 30000
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "label": "Kafka, SASL_PLAINTEXT, GSSAPI",
+      "body": {
+        "## Template": "Kafka, SASL_PLAINTEXT, GSSAPI",
+        "kafka": [
+          {
+            "name": "kafka",
+            "editorTag": "SASL_PLAINTEXT, GSSAPI",
+            "version": 1,
+            "tags": "[]",
+            "configuration": {
+              "kafkaBootstrapServers": {
+                "value": [
+                  "<broker1>:9092",
+                  "<broker2>:9092"
+                ]
+              },
+              "protocol": {
+                "value": "SASL_PLAINTEXT"
+              },
+              "saslMechanism": {
+                "value": "GSSAPI"
+              },
+              "saslJaasConfig": {
+                "value": "com.sun.security.auth.module.Krb5LoginModule required useKeyTab=true storeKey=true useTicketCache=false serviceName=\"kafka\" principal=\"<user>@<REALM>\";"
+              },
+              "keytab": {
+                "file": "kafka.keytab"
               },
               "additionalProperties": {
                 "value": {}

--- a/agent/provisioning.schema.json
+++ b/agent/provisioning.schema.json
@@ -2686,6 +2686,59 @@
       }
     },
     {
+      "label": "Kafka, SASL_PLAINTEXT, GSSAPI",
+      "body": {
+        "## Template": "Kafka, SASL_PLAINTEXT, GSSAPI",
+        "kafka": [
+          {
+            "name": "kafka",
+            "editorTag": "SASL_PLAINTEXT, GSSAPI",
+            "version": 1,
+            "tags": "[]",
+            "configuration": {
+              "kafkaBootstrapServers": {
+                "value": [
+                  "SASL_PLAINTEXT://<broker1>:9092",
+                  "SASL_PLAINTEXT://<broker2>:9092"
+                ]
+              },
+              "protocol": {
+                "value": "SASL_PLAINTEXT"
+              },
+              "saslMechanism": {
+                "value": "GSSAPI"
+              },
+              "saslJaasConfig": {
+                "value": "com.sun.security.auth.module.Krb5LoginModule required useKeyTab=true storeKey=true useTicketCache=false serviceName=\"kafka\" principal=\"<user>@<REALM>\";"
+              },
+              "keytab": {
+                "file": "kafka.keytab"
+              },
+              "## Optional JMX metrics": "Uncomment the properties below to enable JMX metrics",
+              "# metricsPort": {
+                "# value": 9581
+              },
+              "# metricsType": {
+                "# value": ""
+              },
+              "# metricsSsl": {
+                "# value": false
+              },
+              "# metricsUsername": {
+                "# value": ""
+              },
+              "# metricsPassword": {
+                "# value": ""
+              },
+              "# metricsHttpTimeout": {
+                "# value": 30000
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
       "label": "Kafka, SASL_SSL, PLAIN",
       "body": {
         "## Template": "Kafka, SASL_SSL, PLAIN",


### PR DESCRIPTION
Follow-up to the GSSAPI support that was merged in #91.

## Two fixes

1. **Invalid editor tag (bug).** The `Kafka, SASL_SSL, GSSAPI` snippet added in #91 sets `editorTag: "SASL_SSL, GSSAPI"`, but that value was not in the `editorTagKafka` enum. Kafka entries validate `editorTag` against that enum, so applying the snippet produced a document that failed schema validation. This registers the tag.

2. **GSSAPI over SASL_PLAINTEXT.** Kerberos/GSSAPI is valid without TLS too, not only over `SASL_SSL`. Adds a `Kafka, SASL_PLAINTEXT, GSSAPI` template (mirroring how PLAIN/SCRAM each have both protocol variants). The mechanism itself already validated over `SASL_PLAINTEXT` after #91 — this adds the convenience snippet and its editor tag.

## Changes

- Register `SASL_SSL, GSSAPI` and `SASL_PLAINTEXT, GSSAPI` in the `editorTagKafka` (and generic `editorTag`) enums — `provisioning.schema-6.1.json`
- Add a `Kafka, SASL_PLAINTEXT, GSSAPI` template to both `provisioning.schema.json` and `provisioning.schema-6.1.json`

## Verification

- Both schemas compile (ajv). A Kafka connection with `editorTag: "SASL_SSL, GSSAPI"` and one with `editorTag: "SASL_PLAINTEXT, GSSAPI"` now validate; a bogus editor tag is still rejected. `jq` lint and `format-check` pass.